### PR TITLE
Preserve scroll

### DIFF
--- a/src/features/team/TeamOverview.js
+++ b/src/features/team/TeamOverview.js
@@ -74,8 +74,8 @@ const TeamOverview = () => {
   }, [group]); // Når 'group' endres i URL-en, oppdater 'selectedGroup'
   const handleGroupChange = (group) => {
       setSelectedGroup(group);
-     router.push({ pathname: router.pathname, query: { ...router.query, group: group.toLowerCase() }}, undefined, { shallow: true, scroll: false });
-     setMenuOpen(false);
+     router.push({ pathname: router.pathname, query: { ...router.query, group: group.toLowerCase() }}, undefined, { shallow: true, scroll: false }); //Oppdtaer URL-parameteren
+     setMenuOpen(false); // Lukk dropdown når et valg er gjort
   };
     useEffect(() => {
         const handleResize = () => setIsMobile(window.innerWidth <= 1050);


### PR DESCRIPTION
# Preserve scroll position on teams page
## Description
Updates the URL-parameter when switching between group views in teams in a way that preserves the scroll position of the user. This should be integrated with nginx as it only updates the URL string after /team?.
## Notes
Currently this is only implemented on the teams page in TeamOverview.js. For further development also requiring preserved scroll position, the below code can be used to update the URL-parameter (simply change the ...newQuery to reflect the desired update)

`router.push({ pathname: router.pathname, query: { ...router.query, ...newQuery }}, undefined, { shallow: true, scroll: false };`